### PR TITLE
Allow adding "full-bleed" images and code blocks to blog posts

### DIFF
--- a/src/lib/components/atoms/Image.svelte
+++ b/src/lib/components/atoms/Image.svelte
@@ -3,6 +3,7 @@
 
 	export let src: string;
 	export let alt: string;
+	export let fullBleed: boolean | undefined = undefined;
 
 	export let formats: string[] = ['avif', 'webp', 'png'];
 	export let widths: string[] | undefined = undefined;
@@ -36,7 +37,7 @@
 	}
 </script>
 
-<img srcset={buildSrcset()} {src} {alt} loading="lazy" decoding="async" />
+<img srcset={buildSrcset()} {src} {alt} loading="lazy" decoding="async" class:full-bleed={fullBleed} />
 
 <style lang="scss">
 	img {

--- a/src/lib/components/molecules/CodeBlock.svelte
+++ b/src/lib/components/molecules/CodeBlock.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	export let filename: string;
 	export let lang: string;
+	export let fullBleed: boolean | undefined = undefined;
 </script>
 
-<div class="code-block">
+<div class="code-block" class:full-bleed={fullBleed}>
 	{#if filename}
 		<div class="filename">{filename}</div>
 	{/if}

--- a/src/routes/(blog-article)/+layout.svelte
+++ b/src/routes/(blog-article)/+layout.svelte
@@ -97,6 +97,7 @@
 	}
 
 	#article-content {
+		--main-column-width: 65ch;
 		position: relative;
 		padding-top: 40px;
 		padding-bottom: 80px;
@@ -118,21 +119,9 @@
 			padding-left: 30px;
 		}
 
-		display: grid;
-		grid-template-columns:
-			1fr
-			min(65ch, 100%)
-			1fr;
-		grid-row-gap: 30px;
-
-		> * {
-			grid-column: 2;
-		}
-
-		.full-bleed {
-			width: 100%;
-			grid-column: 1 / 4;
-		}
+		display: flex;
+		flex-direction: column;
+		gap: 30px;
 
 		.header {
 			display: flex;
@@ -141,6 +130,8 @@
 			justify-content: center;
 			text-align: center;
 			gap: 10px;
+			width: min(var(--main-column-width), 100%);
+			margin: 0 auto;
 
 			.note {
 				font-size: 90%;
@@ -149,7 +140,8 @@
 		}
 
 		.cover-image {
-			width: 100%;
+			width: min(var(--main-column-width), 100%);
+			margin: 0 auto;
 			max-height: 400px;
 			box-shadow: var(--image-shadow);
 			border-radius: 6px;
@@ -157,12 +149,34 @@
 			img {
 				width: 100%;
 				height: 100%;
+				max-height: 400px;
 				object-fit: cover;
 			}
 		}
 
 		:global(.cover-image img) {
+			max-height: 400px;
 			object-fit: cover;
+		}
+
+		.content {
+			display: grid;
+			grid-template-columns:
+				1fr
+				min(var(--main-column-width), 100%)
+				1fr;
+
+			:global(> *) {
+				grid-column: 2;
+			}
+
+			:global(> .full-bleed) {
+				grid-column: 1 / 4;
+				width: 100%;
+				max-width: 1600px;
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 
 		.tags {

--- a/src/routes/(blog-article)/blog-posts/+page.md
+++ b/src/routes/(blog-article)/blog-posts/+page.md
@@ -38,7 +38,7 @@ To create a new post, create a new folder inside the `src/routes/(blog-article)`
 
 Inside the `+page.md` file, you must start with the front matter, which is a YAML-like syntax that is used to define metadata for the post. The front matter must be the first thing in the file, and must be separated from the rest of the content by three dashes (`---`). An example of a front matter is:
 
-<CodeBlock lang="markdown" fullBleed>
+<CodeBlock lang="markdown">
 
 ```md
 ---

--- a/src/routes/(blog-article)/blog-posts/+page.md
+++ b/src/routes/(blog-article)/blog-posts/+page.md
@@ -38,7 +38,7 @@ To create a new post, create a new folder inside the `src/routes/(blog-article)`
 
 Inside the `+page.md` file, you must start with the front matter, which is a YAML-like syntax that is used to define metadata for the post. The front matter must be the first thing in the file, and must be separated from the rest of the content by three dashes (`---`). An example of a front matter is:
 
-<CodeBlock lang="markdown">
+<CodeBlock lang="markdown" fullBleed>
 
 ```md
 ---
@@ -58,9 +58,9 @@ tags:
 
 I highly recommend the [Front Matter VS Code extension](https://frontmatter.codes/) to manage blog posts. It gives you a nice CMS-like UI to manage the front matter of all blog posts, as well as a preview of their content. It is, of course, optional, and you can manage everything directly in the Markdown files if you prefer.
 
-<Image src="/images/posts/frontmatter-preview-dashboard.png" alt="Screenshot of the Front Matter VS Code extension, showing the dashboard with all posts" />
+<Image fullBleed src="/images/posts/frontmatter-preview-dashboard.png" alt="Screenshot of the Front Matter VS Code extension, showing the dashboard with all posts" />
 
-<Image src="/images/posts/frontmatter-preview-edit.png" alt="Screenshot of the Front Matter VS Code extension, showing the post editing UI" />
+<Image fullBleed src="/images/posts/frontmatter-preview-edit.png" alt="Screenshot of the Front Matter VS Code extension, showing the post editing UI" />
 
 ## RSS
 


### PR DESCRIPTION
The previous "full-bleed" CSS was broken and wasn't used. I've now fixed it so elements in the post with the class "full-bleed" can take up the entire screen instead of being constrained to the text column.

See example:

![Arc 2023-07-31 at 19 07 09](https://github.com/matfantinel/sveltekit-static-blog-template/assets/24247035/2395d509-81dc-4077-b72e-32ddaa25ca68)
